### PR TITLE
Corrected memset call

### DIFF
--- a/docs/binary-exploitation/what-is-the-heap.md
+++ b/docs/binary-exploitation/what-is-the-heap.md
@@ -22,6 +22,7 @@ Let's see how these could be used in a program:
 ```c
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 int main() {
@@ -32,7 +33,7 @@ int main() {
     scanf("%u", &alloc_size);
 
     stuff = malloc(alloc_size + 1);
-    memset(0, stuff, alloc_size + 1);
+    memset(stuff, 0, alloc_size + 1);
 
     read(0, stuff, alloc_size);
 


### PR DESCRIPTION
1. Changed the `memset` call to properly fill allocated memory with zeros. The previous call mistakenly passed 0 as the source, which has been corrected to pass the value to fill the memory with.

2. Added the necessary string.h header, to ensure the declaration of the `memset` function is included. This was missing, causing compilation errors.