### PR TITLE
Reword links to work in both github and site

### DIFF
--- a/docs/binary-exploitation/buffer-overflow.md
+++ b/docs/binary-exploitation/buffer-overflow.md
@@ -4,7 +4,7 @@ A Buffer Overflow is a vulnerability in which data can be written which exceeds 
 
 ## Stack buffer overflow
 
-The simplest and most common buffer overflow is one where the buffer is on [the stack](./what-is-the-stack). Let's look at an example.
+The simplest and most common buffer overflow is one where the buffer is on [the stack](what-is-the-stack.md). Let's look at an example.
 
 ```c
 #include <stdio.h>
@@ -81,7 +81,7 @@ This will fill the `name` buffer with 100 'A's, then overwrite `secret` with the
 
 ### Going one step further
 
-As discussed on [the stack](./what-is-the-stack) page, the instruction that the current function should jump to when it is done is also saved on the stack (denoted as "Saved EIP" in the above stack diagrams). If we can overwrite this, we can control where the program jumps after `main` finishes running, giving us the ability to control what the program does entirely.
+As discussed on [the stack](what-is-the-stack.md) page, the instruction that the current function should jump to when it is done is also saved on the stack (denoted as "Saved EIP" in the above stack diagrams). If we can overwrite this, we can control where the program jumps after `main` finishes running, giving us the ability to control what the program does entirely.
 
 Usually, the end objective in binary exploitation is to get a shell (often called "popping a shell") on the remote computer. The shell provides us with an easy way to run _anything_ we want on the target computer.
 
@@ -99,4 +99,4 @@ Assuming `give_shell` is at 0x08048fd0, we could use something like this: `pytho
 
 We send 108 'A's to overwrite the 100 bytes that is allocated for `name`, the 4 bytes for `secret`, and the 4 bytes for the saved EBP. Then we simply send the little-endian form of `give_shell`'s address, and we would get a shell!
 
-This idea is extended on in [Return Oriented Programming](./return-oriented-programming)
+This idea is extended on in [Return Oriented Programming](return-oriented-programming.md)

--- a/docs/binary-exploitation/heap-exploitation.md
+++ b/docs/binary-exploitation/heap-exploitation.md
@@ -2,7 +2,7 @@
 
 ## Overflow
 
-Much like a [stack buffer overflow](./buffer-overflow/#stack-buffer-overflow), a **heap overflow** is a vulnerability where more data than can fit in the allocated buffer is read in. This could lead to heap metadata corruption, or corruption of other heap objects, which could in turn provide new attack surface.
+Much like a [stack buffer overflow](buffer-overflow.md#stack-buffer-overflow), a **heap overflow** is a vulnerability where more data than can fit in the allocated buffer is read in. This could lead to heap metadata corruption, or corruption of other heap objects, which could in turn provide new attack surface.
 
 
 ## Use After Free (UAF)

--- a/docs/binary-exploitation/relocation-read-only.md
+++ b/docs/binary-exploitation/relocation-read-only.md
@@ -8,7 +8,7 @@ There are two RELRO "modes": partial and full.
 
 Partial RELRO is the default setting in GCC, and nearly all binaries you will see have at least partial RELRO.
 
-From an attackers point-of-view, partial RELRO makes almost no difference, other than it forces the GOT to come before the BSS in memory, eliminating the risk of a [buffer overflows](./buffer-overflow) on a global variable overwriting GOT entries.
+From an attackers point-of-view, partial RELRO makes almost no difference, other than it forces the GOT to come before the BSS in memory, eliminating the risk of a [buffer overflows](buffer-overflow.md) on a global variable overwriting GOT entries.
 
 
 ## Full RELRO

--- a/docs/binary-exploitation/return-oriented-programming.md
+++ b/docs/binary-exploitation/return-oriented-programming.md
@@ -2,7 +2,7 @@
 
 Return Oriented Programming (or ROP) is the idea of chaining together small snippets of assembly with stack control to cause the program to do more complex things.
 
-As we saw in [buffer overflows](./buffer-overflow), having stack control can be very powerful since it allows us to overwrite saved instruction pointers, giving us control over what the program does next. Most programs don't have a convenient `give_shell` function however, so we need to find a way to manually invoke `system` or another `exec` function to get us our shell.
+As we saw in [buffer overflows](buffer-overflow.md), having stack control can be very powerful since it allows us to overwrite saved instruction pointers, giving us control over what the program does next. Most programs don't have a convenient `give_shell` function however, so we need to find a way to manually invoke `system` or another `exec` function to get us our shell.
 
 ## 32 bit
 
@@ -34,7 +34,7 @@ int main() {
 
 We obviously have a stack buffer overflow on the `echo` variable which can give us EIP control when `main` returns. But we don't have a `give_shell` function! So what can we do?
 
-We can call `system` with an argument we control! Since arguments are passed in on the stack in 32-bit Linux programs (see [calling conventions](./what-are-calling-conventions)), if we have stack control, we have argument control.
+We can call `system` with an argument we control! Since arguments are passed in on the stack in 32-bit Linux programs (see [calling conventions](what-are-calling-conventions.md)), if we have stack control, we have argument control.
 
 When main returns, we want our stack to look like something had normally called `system`. Recall what is on the stack after a function has been called:
 
@@ -53,14 +53,14 @@ So `main`'s stack frame needs to look like this:
 ESP ->  0xffff0000: 0x08048450              // return address for main (system's PLT entry)
 ```
 
-Then when `main` returns, it will jump into `system`'s [PLT](./what-is-the-got/#plt) entry and the stack will appear just like `system` had been called normally for the first time.
+Then when `main` returns, it will jump into `system`'s [PLT](what-is-the-got.md#plt) entry and the stack will appear just like `system` had been called normally for the first time.
 
 Note: we don't care about the return address `system` will return to because we will have already gotten our shell by then!
 
 
 ### Arguments
 
-This is a good start, but we need to pass an argument to `system` for anything to happen. As mentioned in the page on [ASLR](./address-space-layout-randomization), the stack and dynamic libraries "move around" each time a program is run, which means we can't easily use data on the stack or a string in libc for our argument. In this case however, we have a very convenient `name` global which will be at a known location in the binary (in the BSS segment).
+This is a good start, but we need to pass an argument to `system` for anything to happen. As mentioned in the page on [ASLR](address-space-layout-randomization.md), the stack and dynamic libraries "move around" each time a program is run, which means we can't easily use data on the stack or a string in libc for our argument. In this case however, we have a very convenient `name` global which will be at a known location in the binary (in the BSS segment).
 
 
 ### Putting it together
@@ -77,7 +77,7 @@ Our exploit will need to do the following:
 
 ## 64 bit
 
-In 64-bit binaries we have to work a bit harder to pass arguments to functions. The basic idea of overwriting the saved RIP is the same, but as discussed in [calling conventions](./what-are-calling-conventions), arguments are passed in registers in 64-bit programs. In the case of running `system`, this means we will need to find a way to control the RDI register.
+In 64-bit binaries we have to work a bit harder to pass arguments to functions. The basic idea of overwriting the saved RIP is the same, but as discussed in [calling conventions](what-are-calling-conventions.md), arguments are passed in registers in 64-bit programs. In the case of running `system`, this means we will need to find a way to control the RDI register.
 
 To do this, we'll use small snippets of assembly in the binary, called "gadgets." These gadgets usually `pop` one or more registers off of the stack, and then call `ret`, which allows us to chain them together by making a large fake call stack.
 

--- a/docs/binary-exploitation/what-are-buffers.md
+++ b/docs/binary-exploitation/what-are-buffers.md
@@ -27,7 +27,7 @@ int main() {
 }
 ```
 
-Or dynamically allocated on the [heap](./what-is-the-heap):
+Or dynamically allocated on the [heap](what-is-the-heap.md):
 
 ```c
 #include <stdio.h>
@@ -44,4 +44,4 @@ int main() {
 
 ## Exploits
 
-Given that buffers commonly hold user input, mistakes when writing to them could result in attacker controlled data being written outside of the buffer's space. See the page on [buffer overflows](./buffer-overflow) for more.
+Given that buffers commonly hold user input, mistakes when writing to them could result in attacker controlled data being written outside of the buffer's space. See the page on [buffer overflows](buffer-overflow.md) for more.

--- a/docs/binary-exploitation/what-are-calling-conventions.md
+++ b/docs/binary-exploitation/what-are-calling-conventions.md
@@ -6,7 +6,7 @@ In Linux binaries, there are really only two commonly used calling conventions: 
 
 ## cdecl
 
-In 32-bit binaries on Linux, function arguments are passed in on [the stack](./what-is-the-stack) in reverse order. A function like this:
+In 32-bit binaries on Linux, function arguments are passed in on [the stack](what-is-the-stack.md) in reverse order. A function like this:
 
 ```c
 int add(int a, int b, int c) {

--- a/docs/binary-exploitation/what-are-registers.md
+++ b/docs/binary-exploitation/what-are-registers.md
@@ -2,6 +2,6 @@
 
 A **register** is a location within the processor that is able to store data, much like RAM. Unlike RAM however, accesses to registers are effectively instantaneous, whereas reads from main memory can take hundreds of CPU cycles to return.
 
-Registers can hold any value: addresses (pointers), results from mathematical operations, characters, etc. Some registers are _reserved_ however, meaning they have a special purpose and are not "general purpose registers" (GPRs). On x86, the only 2 reserved registers are `rip` and `rsp` which hold the address of the next instruction to execute and the address of the [stack](./what-is-the-stack) respectively.
+Registers can hold any value: addresses (pointers), results from mathematical operations, characters, etc. Some registers are _reserved_ however, meaning they have a special purpose and are not "general purpose registers" (GPRs). On x86, the only 2 reserved registers are `rip` and `rsp` which hold the address of the next instruction to execute and the address of the [stack](what-is-the-stack.md) respectively.
 
 On x86, the same register can have different sized accesses for backwards compatability. For example, the `rax` register is the full 64-bit register, `eax` is the low 32 bits of `rax`, `ax` is the low 16 bits, `al` is the low 8 bits, and `ah` is the high 8 bits of `ax` (bits 8-16 of `rax`).

--- a/docs/binary-exploitation/what-is-the-got.md
+++ b/docs/binary-exploitation/what-is-the-got.md
@@ -1,8 +1,8 @@
 # GOT
 
-The Global Offset Table (or GOT) is a section inside of programs that holds addresses of functions that are dynamically linked. As mentioned in the page on [calling conventions](./what-are-calling-conventions), most programs don't include every function they use to reduce binary size. Instead, common functions (like those in libc) are "linked" into the program so they can be saved once on disk and reused by every program.
+The Global Offset Table (or GOT) is a section inside of programs that holds addresses of functions that are dynamically linked. As mentioned in the page on [calling conventions](what-are-calling-conventions.md), most programs don't include every function they use to reduce binary size. Instead, common functions (like those in libc) are "linked" into the program so they can be saved once on disk and reused by every program.
 
-Unless a program is marked [full RELRO](./relocation-read-only), the resolution of function to address in dynamic library is done lazily. All dynamic libraries are loaded into memory along with the main program at launch, however functions are not mapped to their actual code until they're first called. For example, in the following C snippet `puts` won't be resolved to an address in libc until after it has been called once:
+Unless a program is marked [full RELRO](relocation-read-only.md), the resolution of function to address in dynamic library is done lazily. All dynamic libraries are loaded into memory along with the main program at launch, however functions are not mapped to their actual code until they're first called. For example, in the following C snippet `puts` won't be resolved to an address in libc until after it has been called once:
 
 ```c
 int main() {
@@ -16,10 +16,10 @@ To avoid searching through shared libraries each time a function is called, the 
 
 This has two important implications:
 
-1. The GOT contains pointers to libraries which move around due to [ASLR](./address-space-layout-randomization)
+1. The GOT contains pointers to libraries which move around due to [ASLR](address-space-layout-randomization.md)
 2. The GOT is writable
 
-These two facts will become very useful to use in [Return Oriented Programming](./return-oriented-programming)
+These two facts will become very useful to use in [Return Oriented Programming](return-oriented-programming.md)
 
 
 ## PLT


### PR DESCRIPTION
## Description

Fixes #29.

Follows documentation [here](https://www.mkdocs.org/user-guide/writing-your-docs/#linking-to-pages)

## Additional notes

I was going to add [a validation block to check links](https://www.mkdocs.org/user-guide/configuration/#validation) to the `mkdocs.yml` file, but this causes loads of warnings as this project has lots of absolute links. Possibly it may be worth changing these as mkdocs doesn't officially support absolute links.

```
...
WARNING -  Doc file 'challenges/2015/Pwn/contacts.md' contains an absolute link '/binary-exploitation/what-is-a-format-string-vulnerability/',
           it was left as is. Did you mean '../../../binary-exploitation/what-is-a-format-string-vulnerability.md'?
WARNING -  Doc file 'challenges/2015/Pwn/hipster.md' contains an absolute link '/reverse-engineering/what-are-disassemblers/', it was left as
           is. Did you mean '../../../reverse-engineering/what-are-disassemblers.md'?
...
```
