### PR TITLE
fix typo

### DIFF
--- a/docs/web-exploitation/overview.md
+++ b/docs/web-exploitation/overview.md
@@ -1,6 +1,6 @@
 # Web Exploitation
 
-Websites all around the world are programmed using various programming languages. While there are specific vulnerabilities in each programming langrage that the developer should be aware of, there are issues fundamental to the internet that can show up regardless of the chosen language or framework.
+Websites all around the world are programmed using various programming languages. While there are specific vulnerabilities in each programming language that the developer should be aware of, there are issues fundamental to the internet that can show up regardless of the chosen language or framework.
 
 These vulnerabilities often show up in CTFs as web security challenges where the user needs to exploit a bug to gain some kind of higher level privilege.
 


### PR DESCRIPTION
Fixes a small typo where “langrage” was incorrectly spelled. Updated to the correct spelling “language.”