### PR TITLE
Adding to bytecode guide & C pointer bugs

### DIFF
--- a/docs/reverse-engineering/what-is-assembly-machine-code.md
+++ b/docs/reverse-engineering/what-is-assembly-machine-code.md
@@ -1,6 +1,6 @@
 # Assembly/Machine Code
 
-Machine Code or Assembly is code which has been formatted for direct execution by a CPU. Machine Code is the reason why readable programming languages like C, when compiled, cannot be reversed into source code (well [Decompilers]() can sort of, but more on that later).
+Machine code and assembly are the raw instructions your CPU actually runs, which is why compiling a high-level language like C is a one-way street—you can't perfectly reverse it back to the original source (though [Decompilers](what-are-decompilers.md) try their best!). This fundamental translation loss is what makes reverse engineering challenging.
 
 ## From Source to Compilation
 

--- a/docs/reverse-engineering/what-is-bytecode.md
+++ b/docs/reverse-engineering/what-is-bytecode.md
@@ -1,1 +1,102 @@
-# What is bytecode
+# What is Bytecode?
+
+Bytecode is an intermediate code format that sits between your source code and machine code—think of it as a universal translator that lets programs run on any device with the right Virtual Machine. While languages like C compile directly to native machine code (which is fast but platform-specific), bytecode languages like Python and Java use a VM to interpret instructions at runtime, giving you portability across Windows, macOS, Linux, and other platforms. In CTF reverse engineering, bytecode is *gold* because it's way easier to decompile and analyze than raw assembly or C binaries—tools like `uncompyle6` can pull back the logic almost to source-code readability. The trade-off? It's slower than native C code since the VM has to interpret it on the fly, but you gain security, portability, and a much easier reversing target. Bytecode is essentially a middle ground: more portable than C's compiled binaries, more analyzable than assembly, and perfect for understanding how high-level languages execute under the hood.
+
+## How Bytecode Works
+
+Bytecode is a structured intermediate representation that bridges high-level code and CPU execution. Unlike C, which compiles directly to machine code, bytecode languages compile to VM-specific instructions first:
+
+```
+Source Code → Compiler → Bytecode → Virtual Machine → CPU Execution
+```
+
+Compare this to C's direct compilation:
+
+```
+C Source Code → C Compiler → Machine Code → Direct CPU Execution
+```
+
+For example, when you write Python:
+
+```python
+def add(x, y):
+    return x + y
+
+result = add(5, 10)
+print(result)
+```
+
+The Python interpreter compiles this to bytecode and caches it in `.pyc` files. You can disassemble Python bytecode using the `dis` module:
+
+```python
+import dis
+
+def add(x, y):
+    return x + y
+
+dis.dis(add)
+```
+
+Output:
+
+```
+  2           0 LOAD_FAST                0 (x)
+              2 LOAD_FAST                1 (y)
+              4 BINARY_ADD
+              6 RETURN_VALUE
+```
+
+Compare this to equivalent C code:
+
+```c
+#include <stdio.h>
+
+int add(int x, int y) {
+    return x + y;
+}
+
+int main() {
+    int result = add(5, 10);
+    printf("%d\n", result);
+    return 0;
+}
+```
+
+When compiled with `gcc`, this produces machine code directly—no intermediate bytecode layer. You'd need to disassemble it with `objdump` or `gdb` to see the raw assembly instructions.
+
+## Bytecode vs. C Compilation
+
+The key difference is **compilation strategy**:
+
+- **C**: Compiles directly to platform-specific machine code (fast, efficient, but non-portable)
+- **Bytecode Languages (Python, Java)**: Compile to VM-specific bytecode first, then interpret at runtime (portable, but slower)
+
+This is why C code compiled on Linux won't run on macOS without recompilation, but Python bytecode runs everywhere with the same interpreter installed.
+
+## Why Bytecode Matters for Reverse Engineering
+
+In CTF challenges, you'll often encounter bytecode from Python or Java applications. Bytecode is a goldmine because:
+
+- **Decompilability**: Tools like `uncompyle6` can recover near-source-code logic from Python bytecode with remarkable accuracy.
+- **Portability**: Same bytecode runs on your Mac, Windows, or Linux computer—no recompilation needed.
+- **Analysis**: Bytecode is structured and symbolic, making it easier to trace execution flow than raw x86-64 assembly or C binaries.
+- **Security Research**: Malware analysts use bytecode analysis to understand suspicious Python or Java applications without needing full decompilation.
+
+## Key Differences: Bytecode vs. C Machine Code
+
+| Aspect | Bytecode | C Machine Code |
+|--------|----------|--------------|
+| **Platform** | Platform-independent | CPU-specific (x86-64, ARM, etc.) |
+| **Readability** | Symbolic, structured | Raw hex/assembly instructions |
+| **Execution** | VM-interpreted | Direct CPU execution |
+| **Speed** | Slower (VM overhead) | Faster (native execution) |
+| **Reversibility** | Easy to decompile | Hard to reverse to source |
+| **Compilation** | Compile once, run anywhere | Recompile for each platform |
+
+## Tools for Bytecode Analysis
+
+- **Python**: `dis`, `uncompyle6`, `decompyle3`
+- **General**: `Ghidra` (supports multiple formats), `Radare2`
+- **C Comparison**: `objdump`, `gdb`, `Ghidra` (for native binaries)
+
+Bytecode is your friend in CTF reverse engineering—it's the sweet spot between portability and analyzability! 🚀

--- a/docs/reverse-engineering/what-is-c.md
+++ b/docs/reverse-engineering/what-is-c.md
@@ -42,7 +42,7 @@ A good way to explore this relationship is to use this online [GCC Explorer](htt
 In regards to CTF, many reverse engineering and exploitation CTF challenges are written in C because the language compiles down directly to assembly and there are little to no safeguards in the language. This means developers must manually handle both. Of course, this can lead to mistakes which can sometimes lead to security issues.
 
 !!! note
-    Other higher level langauges like Python manage memory and garbage collection for you. Google Golang was inspired by C, but adds in functionality like garbage collection and memory safety.
+    Other higher level languages like Python manage memory and garbage collection for you. Google Golang was inspired by C, but adds in functionality like garbage collection and memory safety.
 
 There are some examples of famously vulnerable functions in C which are still available and can still result in vulnerabilities:
 
@@ -103,7 +103,7 @@ int integers[ 10 ] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
 Arrays allow programmers to group data into logical containers.
 
-To access the individual elements of an array we access the contents by their "index". Most programming langauges today start counting from 0. So to take our previous example:
+To access the individual elements of an array we access the contents by their "index". Most programming languages today start counting from 0. So to take our previous example:
 
 ```c
 int integers[ 10 ] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};

--- a/docs/reverse-engineering/what-is-c.md
+++ b/docs/reverse-engineering/what-is-c.md
@@ -125,7 +125,7 @@ Because the computer knows the data type used for every element in the array, th
 For example if we know that the base address of an array is 1000 and we know that each integer takes 8 bytes, we know that if we have 8 integers right next to each other, we can get the integer at the 4th index with the following math:
 
 ```c
-1000 + (4 * 8) =  1032
+1000 + (8 * 4) =  1032
 ```
 
 ```c

--- a/docs/reverse-engineering/what-is-c.md
+++ b/docs/reverse-engineering/what-is-c.md
@@ -135,3 +135,70 @@ addrs  1000  1008  1016  1024  1032  1040  1048  1056
 ```
 
 ## Memory Management
+
+### Memory safety issues with Pointers
+
+Because C requires programmers to manually manage memory, it trusts the developer to handle pointers safely. Since the compiler does not include built-in bounds checking or garbage collection (unlike higher-level languages), pointers are often the source of bugs and security vulnerabilities. 
+
+Below are four of the most common memory safety issues related to pointers:
+
+#### 1. Out-of-Bounds Access (Pointer Arithmetic)
+
+As mentioned in the Arrays section, C allows you to use mathematical operations on pointers to navigate memory. However, C does not check if you have moved past the bounds of your allocated memory. If you shift a pointer too far, you will begin reading or writing to unallocated memory or memory owned by other parts of the program. This can lead to application crashes or allow attackers to overwrite sensitive data.
+
+```c
+int arr[3] = {10, 20, 30};
+int *ptr = arr; // ptr points to the first element (10)
+
+ptr += 5; // Shifts the pointer 5 positions forward
+
+// The program is now accessing memory outside of the 'arr' bounds
+*ptr = 99; 
+
+```
+
+#### 2. Dangling Pointers (Use-After-Free)
+
+When you dynamically allocate memory using functions like `malloc`, you must eventually release it back to the system using `free`. A dangling pointer occurs when you free the memory, but the pointer variable retains the old memory address. If your program writes to this address later, it will corrupt data, as that memory may have been reallocated for another purpose by the operating system.
+
+```c
+#include <stdlib.h>
+
+int *ptr = (int *)malloc(sizeof(int)); // Allocate memory
+*ptr = 42; 
+
+free(ptr); // Release the memory back to the system
+
+// ptr still holds the old address, but the program no longer owns the memory
+*ptr = 100; 
+
+```
+
+#### 3. Uninitialized Pointers
+
+If a pointer is declared but not assigned a specific memory address, it will simply hold whatever random data was previously sitting in that location. Dereferencing an uninitialized pointer means the program is attempting to access a random memory address, which typically results in an immediate crash known as a segmentation fault.
+
+```c
+int *uninitialized_ptr; // Declared, but not assigned a valid address
+
+// Attempts to write to a random memory address, causing a segmentation fault
+*uninitialized_ptr = 5; 
+
+```
+
+#### 4. Null Pointer Dereference
+
+To prevent uninitialized pointers, it is standard practice to set pointers to `NULL` (address `0x0`) when they are not actively pointing to valid data. However, if a program attempts to read or write to a `NULL` pointer before it is assigned a valid address, the operating system will intervene and crash the program to protect the system.
+
+```c
+#include <stddef.h>
+
+int *ptr = NULL; // Explicitly points to nothing (0x0)
+
+// The operating system will terminate the program because address 0x0 cannot be accessed
+int value = *ptr; 
+
+```
+
+
+


### PR DESCRIPTION
fixed type with Just pushing some updates to the RE docs!

Added a full breakdown of what bytecode is and why it matters for CTFs, plus a new section on common memory safety issues with C pointers. I also fixed a couple of minor typos and math errors in the C doc along the way.