### PR TITLE
Add GitHub Actions workflow to auto-deploy site to gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy site
+
+# Automatically build the MkDocs site and publish it to the gh-pages
+# branch whenever changes land on master. Also runnable on demand.
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+# Allow the job's GITHUB_TOKEN to push the built site to gh-pages.
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          # Full history is required by the
+          # git-revision-date-localized plugin to read page dates.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build and deploy to gh-pages
+        # gh-deploy builds the site and force-pushes it to the
+        # gh-pages branch, exactly like a manual local deploy.
+        run: mkdocs gh-deploy --force --no-history

--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ The site is maintained by the [OSIRIS Lab](https://osiris.cyber.nyu.edu/) in col
     ```
 
 ---
+### Deployment
+
+The site is built and published to the `gh-pages` branch automatically by a [GitHub Actions workflow](.github/workflows/deploy.yml). There is no manual deploy step.
+
+- **On every push to `master`**, the workflow installs the dependencies, builds the site with MkDocs, and publishes the output to the `gh-pages` branch (which GitHub Pages serves). You can also trigger it manually from the **Actions** tab (**Run workflow**).
+- The workflow uses the built-in `GITHUB_TOKEN` (granted `contents: write`) to push to `gh-pages` — no personal tokens or secrets are required.
+- It checks out the full git history (`fetch-depth: 0`) so the `git-revision-date-localized` plugin can read each page's last-modified date.
+
+To deploy manually (e.g. from a fork), you can still run:
+```sh
+mkdocs gh-deploy --force
+```
+
+---
 ### Contributing
 
 > First off, thank you so much for contributing to CTF101's wiki repository. It's contributions from people like you who makes this page what it is. Thank you for making this page be the first step for many more security engineers!


### PR DESCRIPTION
Builds the MkDocs site and publishes to gh-pages on every push to master (and on demand via workflow_dispatch), replacing the manual mkdocs gh-deploy step.

#68 - Closes this issue with the PR