### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ The site is maintained by the [OSIRIS Lab](https://osiris.cyber.nyu.edu/) in col
     ```
 
 ---
+### Analytics
+
+CTF101 uses Google Analytics / GA4 for basic traffic analytics. The Measurement
+ID is configured in `mkdocs.yml`, and the local initialization code lives in
+`docs/js/analytics.js`.
+
+The GA4 property is owned by an OSIRIS-controlled Google account, not by an
+individual contributor. If the Measurement ID needs to change, update both the
+Google tag URL in `mkdocs.yml` and the `gtag("config", "...")` value in
+`docs/js/analytics.js`.
+
+To test locally, run `mkdocs serve`, open the local site, and check the browser
+developer tools Network tab for a request to `googletagmanager.com/gtag/js`.
+
+---
 ### Contributing
 
 > First off, thank you so much for contributing to CTF101's wiki repository. It's contributions from people like you who makes this page what it is. Thank you for making this page be the first step for many more security engineers!

--- a/docs/js/analytics.js
+++ b/docs/js/analytics.js
@@ -1,0 +1,8 @@
+window.dataLayer = window.dataLayer || [];
+
+function gtag() {
+  dataLayer.push(arguments);
+}
+
+gtag("js", new Date());
+gtag("config", "G-EBSZGBX94Z");

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,8 @@ markdown_extensions:
 extra_javascript:
   - js/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+  - https://www.googletagmanager.com/gtag/js?id=G-EBSZGBX94Z
+  - js/analytics.js
 
 docs_dir: docs/
 nav:


### PR DESCRIPTION
## Summary

Adds Google Analytics / GA4 tracking for CTF101.

This addresses #45 by:

- loading the Google tag script through `mkdocs.yml`
- adding a small local `docs/js/analytics.js` initializer
- configuring GA4 with the OSIRIS-provided Measurement ID: `G-EBSZGBX94Z`
- documenting the analytics setup in `README.md` for future maintainers

## Notes

The Measurement ID was provided by OSIRIS/Naman from the lab-controlled Google account, so the analytics property is not tied to my personal account.

## Testing

Ran `git diff --cached --check` with no output.

Ran the MkDocs site locally and confirmed that it builds and serves successfully at `http://127.0.0.1:8000/`.

Confirmed in Chrome DevTools that the GA4 tag script loads successfully with the OSIRIS-provided Measurement ID:

`https://www.googletagmanager.com/gtag/js?id=G-EBSZGBX94Z`

I do not have access to the OSIRIS Google Analytics property, so I could not verify events inside the GA dashboard.

Closes #45