### PR TITLE
Document pwndbg installation and setup

### DIFF
--- a/docs/binary-exploitation/pwndbg-setup.md
+++ b/docs/binary-exploitation/pwndbg-setup.md
@@ -160,6 +160,12 @@ pwndbg ./challenge
 
 Installation methods that integrate pwndbg into a system-provided GDB may require additional configuration. Consult the official [pwndbg setup documentation](https://pwndbg.re/stable/setup/) for installation-specific instructions.
 
+## Decompiler integration
+
+Pwndbg can connect a debugging session with supported decompilers, allowing you to use live debugger information alongside decompiled code.
+
+For configuration instructions and supported decompilers, see the [official pwndbg decompiler integration guide](https://pwndbg.re/2026.07.29/tutorials/decompiler-integration/).
+
 ## Next steps
 
 After installing pwndbg, review [The GNU Debugger (GDB)](../reverse-engineering/what-is-gdb.md) to learn the basic debugger commands used for breakpoints, stepping, memory inspection, and program execution.

--- a/docs/binary-exploitation/pwndbg-setup.md
+++ b/docs/binary-exploitation/pwndbg-setup.md
@@ -1,0 +1,167 @@
+# Pwndbg Setup
+
+[Pwndbg](https://pwndbg.re/) is an extension for debuggers such as GDB that adds commands and displays designed for low-level software debugging and binary exploitation. It makes information such as registers, stack contents, disassembly, and memory mappings easier to inspect while working on CTF challenges.
+
+This page covers installing the GDB version of pwndbg, verifying that it works, and opening a binary. For general debugger commands such as breakpoints, stepping, and examining memory, see [The GNU Debugger (GDB)](../reverse-engineering/what-is-gdb.md).
+
+## Supported environments
+
+Pwndbg provides supported installation methods for Linux and macOS. For most Linux ELF binary exploitation challenges, use the GDB version provided through the `pwndbg` command.
+
+On macOS, GDB has platform limitations. The LLDB version of pwndbg may be more appropriate when debugging native Mach-O binaries. However, many CTF binary exploitation challenges use Linux ELF binaries and are easiest to work with inside a Linux virtual machine, container, or remote environment.
+
+## Install pwndbg-gdb
+
+The recommended installation method uses the official pwndbg installer.
+
+### Install for the current user
+
+This installation does not require root access:
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+    'https://install.pwndbg.re' |
+    sh -s -- -t pwndbg-gdb -u
+```
+
+After installation, restart your terminal or follow any instructions printed by the installer to add the program to your `PATH`.
+
+### Install for all users
+
+A system-wide installation requires root permissions:
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+    'https://install.pwndbg.re' |
+    sh -s -- -t pwndbg-gdb
+```
+
+Review scripts before running them with elevated permissions, especially when working outside a disposable CTF environment.
+
+## Install with Homebrew on macOS
+
+Pwndbg also provides an official Homebrew package for its GDB version:
+
+```bash
+brew install pwndbg/tap/pwndbg-gdb
+```
+
+For native macOS Mach-O binaries, consider using the LLDB version instead:
+
+```bash
+brew install pwndbg/tap/pwndbg-lldb
+```
+
+The LLDB version is launched with `pwndbg-lldb`.
+
+## Install from source
+
+Developers who need the source repository can install pwndbg using its setup script:
+
+```bash
+git clone https://github.com/pwndbg/pwndbg
+cd pwndbg
+./setup.sh
+```
+
+The portable installer is simpler for most CTF participants. A source installation is mainly useful when developing pwndbg, testing recent changes, or using a custom debugger configuration.
+
+## Verify the installation
+
+Launch pwndbg without a target:
+
+```bash
+pwndbg
+```
+
+A successful installation opens GDB with pwndbg loaded. The prompt should resemble:
+
+```text
+pwndbg>
+```
+
+Exit the debugger with:
+
+```text
+quit
+```
+
+## Open a binary
+
+Pass the path of an executable to the `pwndbg` command:
+
+```bash
+pwndbg ./challenge
+```
+
+Pwndbg loads the executable but does not immediately run it. At the `pwndbg>` prompt, start the program with:
+
+```text
+run
+```
+
+For a binary that requires command-line arguments, place them after the executable:
+
+```bash
+pwndbg --args ./challenge argument1 argument2
+```
+
+You can also assign arguments from inside pwndbg:
+
+```text
+set args argument1 argument2
+run
+```
+
+## Common setup problems
+
+### The `pwndbg` command is not found
+
+Restart the terminal after installation. If the command is still unavailable, check whether the installation directory was added to your `PATH`.
+
+Display your current path with:
+
+```bash
+echo "$PATH"
+```
+
+The installer may print an additional command that must be added to your shell configuration file, such as `~/.bashrc` or `~/.zshrc`.
+
+### GDB cannot start the program
+
+Confirm that the binary exists and is executable:
+
+```bash
+ls -l ./challenge
+chmod +x ./challenge
+```
+
+Also confirm that the binary matches your operating system and architecture:
+
+```bash
+file ./challenge
+```
+
+A Linux ELF binary will not run directly as a native macOS executable. Use a Linux virtual machine, container, or remote Linux environment for those challenges.
+
+### Permission errors while debugging
+
+Some operating systems restrict debugger access to processes. When possible, debug a program that you launched yourself rather than attaching to an unrelated process.
+
+Avoid running pwndbg as root unless the challenge environment specifically requires it. Running debugging tools with elevated privileges increases the impact of mistakes or untrusted debugger scripts.
+
+### Pwndbg opens but does not load
+
+Run the standalone `pwndbg` command rather than plain `gdb`:
+
+```bash
+pwndbg ./challenge
+```
+
+Installation methods that integrate pwndbg into a system-provided GDB may require additional configuration. Consult the official [pwndbg setup documentation](https://pwndbg.re/stable/setup/) for installation-specific instructions.
+
+## Next steps
+
+After installing pwndbg, review [The GNU Debugger (GDB)](../reverse-engineering/what-is-gdb.md) to learn the basic debugger commands used for breakpoints, stepping, memory inspection, and program execution.
+
+Additional pwndbg-specific CTF commands will be covered in the follow-up command reference.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,6 +155,7 @@ nav:
   #  Binary Exploitation Section
   - Binary Exploitation:
       - Overview: "binary-exploitation/overview.md"
+      - Pwndbg Setup: "binary-exploitation/pwndbg-setup.md"
       - Registers: "binary-exploitation/what-are-registers.md"
       - The Stack: "binary-exploitation/what-is-the-stack.md"
       - Calling Conventions: "binary-exploitation/what-are-calling-conventions.md"


### PR DESCRIPTION
## Summary

Adds a beginner-focused pwndbg setup guide covering:

- supported environments
- the official installer
- Homebrew installation on macOS
- source installation
- installation verification
- opening binaries
- common setup problems

The page also links to the existing GDB guide for general debugger commands and is added to the Binary Exploitation navigation.

## Testing

- `mkdocs build --strict`
- Reviewed the page locally with `mkdocs serve`

Closes #71.