### PR TITLE
Fix stack pointer values in call diagrams

### DIFF
--- a/docs/binary-exploitation/what-is-the-stack.md
+++ b/docs/binary-exploitation/what-is-the-stack.md
@@ -159,7 +159,7 @@ Finally, `printf` is called, which pushes the address of the next instruction to
 
 ```asm
 EIP = 0x080482e0
-ESP = 0xfffeffe4
+ESP = 0xfffeffe0
 EBP = 0xfffefffc
 
         0xffff0004: 0xffffa0a0              // say_hi argument 1
@@ -178,18 +178,18 @@ Once `printf` has returned, the `leave` instruction moves `ebp` into `esp`, and 
 
 ```asm
 EIP = 0x08048426 (ret)
-ESP = 0xfffefffc
+ESP = 0xffff0000
 EBP = 0xffff002c
 
         0xffff0004: 0xffffa0a0              // say_hi argument 1
 ESP ->  0xffff0000: 0x0804845a              // Return address for say_hi
 ```
 
-And finally, `ret` pops the saved instruction pointer into `eip` which causes the program to return to main with the same `esp`, `ebp`, and stack contents as when `say_hi` was initially called.
+Finally, `ret` pops the saved instruction pointer into `eip`, returning execution to `main`. Popping the return address advances `esp` by four bytes, restoring it to the value it had immediately before the `call` instruction.
 
 ```asm
 EIP = 0x0804845a (add esp, 0x10)
-ESP = 0xffff0000
+ESP = 0xffff0004
 EBP = 0xffff002c
 
 ESP ->  0xffff0004: 0xffffa0a0              // say_hi argument 1


### PR DESCRIPTION
## Summary

Corrects inconsistent `ESP` values in the stack walkthrough.

The page previously showed register values that did not match the stack pointer arrows after:

- calling `printf`
- executing `leave`
- executing `ret`

This change also clarifies that `ret` advances `esp` by four bytes and restores it to the value it had immediately before the caller executed `call`.

## Testing

- `git diff --check`
- `mkdocs build --strict`

Closes #47.